### PR TITLE
Use json5 for full theme compat

### DIFF
--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -15,6 +15,7 @@
     "url": "git+https://github.com/octref/shiki.git"
   },
   "dependencies": {
+    "json5": "^2.1.0",
     "vscode-textmate": "https://github.com/octref/vscode-textmate"
   }
 }

--- a/packages/themes/src/loadTheme.ts
+++ b/packages/themes/src/loadTheme.ts
@@ -3,11 +3,12 @@ import { IRawTheme, IRawThemeSetting } from 'vscode-textmate'
 import * as fs from 'fs'
 import * as path from 'path'
 import { parse as plistParse } from './plist'
+import JSON5 from 'json5';
 
 function loadJSONTheme(themePath: string): IRawTheme {
   const fileContents = fs.readFileSync(themePath, 'utf-8')
 
-  return JSON.parse(fileContents)
+  return JSON5.parse(fileContents)
 }
 function loadPListTheme(themePath: string): IRawTheme {
   const fileContents = fs.readFileSync(themePath, 'utf-8')
@@ -32,7 +33,7 @@ function toShikiTheme(rawTheme: IRawTheme): IShikiTheme {
 }
 
 /**
- * 
+ *
  * @param themePath Absolute path to theme.json / theme.tmTheme
  */
 export function loadTheme(themePath: string): IShikiTheme {


### PR DESCRIPTION
VS Code uses JSON5 to parse themes, which is why I can have comments in my theme file. For Shiki to work with all themes, this package should use JSON5 too . Thanks! 