### PR TITLE
[languages] Move path.resolve() for better static analysis

### DIFF
--- a/packages/languages/src/lang.ts
+++ b/packages/languages/src/lang.ts
@@ -118,295 +118,295 @@ export const languages: ILanguageRegistration[] = [
   {
     id: 'bat',
     scopeName: 'source.dosbatch',
-    path: '../data/grammars/Batch File.tmLanguage',
+    path: path.resolve(__dirname, '../data/grammars/Batch File.tmLanguage'),
     aliases: ['batch']
   },
   {
     id: 'clojure',
     scopeName: 'source.clojure',
-    path: '../data/grammars/Clojure.tmLanguage',
+    path: path.resolve(__dirname, '../data/grammars/Clojure.tmLanguage'),
     aliases: ['clj']
   },
   {
     id: 'coffeescript',
     scopeName: 'source.coffee',
-    path: '../data/grammars/coffeescript.json',
+    path: path.resolve(__dirname, '../data/grammars/coffeescript.json'),
     aliases: ['coffee']
   },
   {
     id: 'c',
     scopeName: 'source.c',
-    path: '../data/grammars/c.json',
+    path: path.resolve(__dirname, '../data/grammars/c.json'),
     aliases: []
   },
   {
     id: 'cpp',
     scopeName: 'source.cpp',
-    path: '../data/grammars/c++.json',
+    path: path.resolve(__dirname, '../data/grammars/c++.json'),
     aliases: ['c++']
   },
   {
     id: 'csharp',
     scopeName: 'source.cs',
-    path: '../data/grammars/csharp.tmLanguage.json',
+    path: path.resolve(__dirname, '../data/grammars/csharp.tmLanguage.json'),
     aliases: []
   },
   {
     id: 'css',
     scopeName: 'source.css',
-    path: '../data/grammars/css.plist',
+    path: path.resolve(__dirname, '../data/grammars/css.plist'),
     aliases: []
   },
   {
     id: 'diff',
     scopeName: 'source.diff',
-    path: '../data/grammars/diff.tmLanguage',
+    path: path.resolve(__dirname, '../data/grammars/diff.tmLanguage'),
     aliases: []
   },
   {
     id: 'dockerfile',
     scopeName: 'source.dockerfile',
-    path: '../data/grammars/Dockerfile.tmLanguage',
+    path: path.resolve(__dirname, '../data/grammars/Dockerfile.tmLanguage'),
     aliases: ['docker']
   },
   {
     id: 'fsharp',
     scopeName: 'source.fsharp',
-    path: '../data/grammars/fsharp.json',
+    path: path.resolve(__dirname, '../data/grammars/fsharp.json'),
     aliases: ['f#']
   },
   {
     id: 'git-commit',
     scopeName: 'text.git-commit',
-    path: '../data/grammars/git-commit.tmLanguage',
+    path: path.resolve(__dirname, '../data/grammars/git-commit.tmLanguage'),
     aliases: []
   },
   {
     id: 'git-rebase',
     scopeName: 'text.git-rebase',
-    path: '../data/grammars/git-rebase.tmLanguage',
+    path: path.resolve(__dirname, '../data/grammars/git-rebase.tmLanguage'),
     aliases: []
   },
   {
     id: 'go',
     scopeName: 'source.go',
-    path: '../data/grammars/go.json',
+    path: path.resolve(__dirname, '../data/grammars/go.json'),
     aliases: []
   },
   {
     id: 'groovy',
     scopeName: 'source.groovy',
-    path: '../data/grammars/Groovy.tmLanguage',
+    path: path.resolve(__dirname, '../data/grammars/Groovy.tmLanguage'),
     aliases: []
   },
   {
     id: 'handlebars',
     scopeName: 'text.html.handlebars',
-    path: '../data/grammars/Handlebars.json',
+    path: path.resolve(__dirname, '../data/grammars/Handlebars.json'),
     aliases: ['hbs']
   },
   {
     id: 'html',
     scopeName: 'text.html.basic',
-    path: '../data/grammars/html.json',
+    path: path.resolve(__dirname, '../data/grammars/html.json'),
     aliases: ['htm', 'xhtml']
   },
   {
     id: 'ini',
     scopeName: 'source.properties',
-    path: '../data/grammars/properties.plist',
+    path: path.resolve(__dirname, '../data/grammars/properties.plist'),
     aliases: []
   },
   {
     id: 'properties',
     scopeName: 'source.properties',
-    path: '../data/grammars/properties.plist',
+    path: path.resolve(__dirname, '../data/grammars/properties.plist'),
     aliases: []
   },
   {
     id: 'jade',
     scopeName: 'text.jade',
-    path: '../data/grammars/Jade.json',
+    path: path.resolve(__dirname, '../data/grammars/Jade.json'),
     aliases: []
   },
   {
     id: 'java',
     scopeName: 'source.java',
-    path: '../data/grammars/java.json',
+    path: path.resolve(__dirname, '../data/grammars/java.json'),
     aliases: []
   },
   {
     id: 'jsx',
     scopeName: 'source.js',
-    path: '../data/grammars/JavaScript.tmLanguage.json',
+    path: path.resolve(__dirname, '../data/grammars/JavaScript.tmLanguage.json'),
     aliases: []
   },
   {
     id: 'javascript',
     scopeName: 'source.js',
-    path: '../data/grammars/JavaScript.tmLanguage.json',
+    path: path.resolve(__dirname, '../data/grammars/JavaScript.tmLanguage.json'),
     aliases: ['js']
   },
   {
     id: 'json',
     scopeName: 'source.json',
-    path: '../data/grammars/JSON.tmLanguage',
+    path: path.resolve(__dirname, '../data/grammars/JSON.tmLanguage'),
     aliases: []
   },
   {
     id: 'jsonc',
     scopeName: 'source.json.comments',
-    path: '../data/grammars/JSONC.tmLanguage.json',
+    path: path.resolve(__dirname, '../data/grammars/JSONC.tmLanguage.json'),
     aliases: []
   },
   {
     id: 'less',
     scopeName: 'source.css.less',
-    path: '../data/grammars/less.tmLanguage.json',
+    path: path.resolve(__dirname, '../data/grammars/less.tmLanguage.json'),
     aliases: []
   },
   {
     id: 'lua',
     scopeName: 'source.lua',
-    path: '../data/grammars/lua.json',
+    path: path.resolve(__dirname, '../data/grammars/lua.json'),
     aliases: []
   },
   {
     id: 'makefile',
     scopeName: 'source.makefile',
-    path: '../data/grammars/Makefile.json',
+    path: path.resolve(__dirname, '../data/grammars/Makefile.json'),
     aliases: []
   },
   {
     id: 'markdown',
     scopeName: 'text.html.markdown',
-    path: '../data/grammars/markdown.tmLanguage',
+    path: path.resolve(__dirname, '../data/grammars/markdown.tmLanguage'),
     aliases: ['md']
   },
   {
     id: 'objective-c',
     scopeName: 'source.objc',
-    path: '../data/grammars/Objective-C.tmLanguage',
+    path: path.resolve(__dirname, '../data/grammars/Objective-C.tmLanguage'),
     aliases: ['objc']
   },
   {
     id: 'perl',
     scopeName: 'source.perl',
-    path: '../data/grammars/Perl.plist',
+    path: path.resolve(__dirname, '../data/grammars/Perl.plist'),
     aliases: []
   },
   {
     id: 'perl6',
     scopeName: 'source.perl.6',
-    path: '../data/grammars/Perl 6.tmLanguage',
+    path: path.resolve(__dirname, '../data/grammars/Perl 6.tmLanguage'),
     aliases: []
   },
   {
     id: 'php',
     scopeName: 'text.html.php',
-    path: '../data/grammars/php.json',
+    path: path.resolve(__dirname, '../data/grammars/php.json'),
     aliases: []
   },
   {
     id: 'powershell',
     scopeName: 'source.powershell',
-    path: '../data/grammars/PowershellSyntax.tmLanguage',
+    path: path.resolve(__dirname, '../data/grammars/PowershellSyntax.tmLanguage'),
     aliases: ['ps', 'ps1']
   },
   {
     id: 'python',
     scopeName: 'source.python',
-    path: '../data/grammars/MagicPython.tmLanguage.json',
+    path: path.resolve(__dirname, '../data/grammars/MagicPython.tmLanguage.json'),
     aliases: ['py']
   },
   {
     id: 'r',
     scopeName: 'source.r',
-    path: '../data/grammars/R.plist',
+    path: path.resolve(__dirname, '../data/grammars/R.plist'),
     aliases: []
   },
   {
     id: 'razor',
     scopeName: 'text.html.cshtml',
-    path: '../data/grammars/cshtml.json',
+    path: path.resolve(__dirname, '../data/grammars/cshtml.json'),
     aliases: []
   },
   {
     id: 'ruby',
     scopeName: 'source.ruby',
-    path: '../data/grammars/Ruby.plist',
+    path: path.resolve(__dirname, '../data/grammars/Ruby.plist'),
     aliases: ['rb']
   },
   {
     id: 'rust',
     scopeName: 'source.rust',
-    path: '../data/grammars/rust.json',
+    path: path.resolve(__dirname, '../data/grammars/rust.json'),
     aliases: []
   },
   {
     id: 'scss',
     scopeName: 'source.css.scss',
-    path: '../data/grammars/scss.json',
+    path: path.resolve(__dirname, '../data/grammars/scss.json'),
     aliases: []
   },
   {
     id: 'shaderlab',
     scopeName: 'source.shaderlab',
-    path: '../data/grammars/shaderlab.json',
+    path: path.resolve(__dirname, '../data/grammars/shaderlab.json'),
     aliases: ['shader']
   },
   {
     id: 'shellscript',
     scopeName: 'source.shell',
-    path: '../data/grammars/Shell-Unix-Bash.tmLanguage.json',
+    path: path.resolve(__dirname, '../data/grammars/Shell-Unix-Bash.tmLanguage.json'),
     aliases: ['shell', 'bash', 'sh', 'zsh']
   },
   {
     id: 'sql',
     scopeName: 'source.sql',
-    path: '../data/grammars/SQL.plist',
+    path: path.resolve(__dirname, '../data/grammars/SQL.plist'),
     aliases: []
   },
   {
     id: 'swift',
     scopeName: 'source.swift',
-    path: '../data/grammars/swift.json',
+    path: path.resolve(__dirname, '../data/grammars/swift.json'),
     aliases: []
   },
   {
     id: 'typescript',
     scopeName: 'source.ts',
-    path: '../data/grammars/TypeScript.tmLanguage.json',
+    path: path.resolve(__dirname, '../data/grammars/TypeScript.tmLanguage.json'),
     aliases: ['ts']
   },
   {
     id: 'tsx',
     scopeName: 'source.tsx',
-    path: '../data/grammars/TypeScriptReact.tmLanguage.json',
+    path: path.resolve(__dirname, '../data/grammars/TypeScriptReact.tmLanguage.json'),
     aliases: []
   },
   {
     id: 'vb',
     scopeName: 'source.asp.vb.net',
-    path: '../data/grammars/ASPVBnet.plist',
+    path: path.resolve(__dirname, '../data/grammars/ASPVBnet.plist'),
     aliases: ['cmd']
   },
   {
     id: 'xml',
     scopeName: 'text.xml',
-    path: '../data/grammars/xml.json',
+    path: path.resolve(__dirname, '../data/grammars/xml.json'),
     aliases: []
   },
   {
     id: 'xsl',
     scopeName: 'text.xml.xsl',
-    path: '../data/grammars/xsl.json',
+    path: path.resolve(__dirname, '../data/grammars/xsl.json'),
     aliases: []
   },
   {
     id: 'yaml',
     scopeName: 'source.yaml',
-    path: '../data/grammars/yaml.json',
+    path: path.resolve(__dirname, '../data/grammars/yaml.json'),
     aliases: ['yml']
   },
   /**
@@ -415,58 +415,55 @@ export const languages: ILanguageRegistration[] = [
   {
     id: 'haml',
     scopeName: 'text.haml',
-    path: '../data/extraGrammars/haml.json',
+    path: path.resolve(__dirname, '../data/extraGrammars/haml.json'),
     aliases: []
   },
   {
     id: 'graphql',
     scopeName: 'source.graphql',
-    path: '../data/extraGrammars/graphql.json',
+    path: path.resolve(__dirname, '../data/extraGrammars/graphql.json'),
     aliases: []
   },
   {
     id: 'sass',
     scopeName: 'source.sass',
-    path: '../data/extraGrammars/sass.tmLanguage',
+    path: path.resolve(__dirname, '../data/extraGrammars/sass.tmLanguage'),
     aliases: []
   },
   {
     id: 'stylus',
     scopeName: 'source.stylus',
-    path: '../data/extraGrammars/stylus.json',
+    path: path.resolve(__dirname, '../data/extraGrammars/stylus.json'),
     aliases: ['styl']
   },
   {
     id: 'postcss',
     scopeName: 'source.css.postcss',
-    path: '../data/extraGrammars/postcss.json',
+    path: path.resolve(__dirname, '../data/extraGrammars/postcss.json'),
     aliases: []
   },
   {
     id: 'vue',
     scopeName: 'source.vue',
-    path: '../data/extraGrammars/vue.json',
+    path: path.resolve(__dirname, '../data/extraGrammars/vue.json'),
     aliases: []
   },
   {
     id: 'vue-html',
     scopeName: 'text.html.vue-html',
-    path: '../data/extraGrammars/vue-html.json',
+    path: path.resolve(__dirname, '../data/extraGrammars/vue-html.json'),
     aliases: []
   },
   {
     id: 'latex',
     scopeName: 'text.tex.latex',
-    path: '../data/extraGrammars/latex.plist',
+    path: path.resolve(__dirname, '../data/extraGrammars/latex.plist'),
     aliases: ['tex']
   },
   {
     id: 'toml',
     scopeName: 'source.toml',
-    path: '../data/extraGrammars/TOML.tmLanguage',
+    path: path.resolve(__dirname, '../data/extraGrammars/TOML.tmLanguage'),
     aliases: []
   }
 ]
-languages.forEach(l => {
-  l.path = path.resolve(__dirname, l.path)
-})


### PR DESCRIPTION
This moves the `path.resolve()` in place so that static analysis tools such as webpack and node-file-trace can determine that the assets in `../data/grammars` should be bundled.

Fixes https://twitter.com/browniefed/status/1288502416732614656